### PR TITLE
Move aws.S3.role to aws.role

### DIFF
--- a/helm/fluent-logshipping-app/templates/fluentd/deployment.yaml
+++ b/helm/fluent-logshipping-app/templates/fluentd/deployment.yaml
@@ -44,11 +44,11 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.fluentd.image.name }}:{{ .Values.fluentd.image.tag }}
         env:
         - name: FLUENTD_OPT
-          value: --no-supervisor -q 
+          value: --no-supervisor -q
         {{- if .Values.fluentd.aws.cloudWatch.enabled }}
         - name: AWS_REGION
           value: "{{ .Values.fluentd.aws.cloudWatch.region }}"
-        {{- end}}  
+        {{- end}}
         resources:
           limits:
             cpu: 30m
@@ -66,8 +66,8 @@ spec:
         configMap:
           defaultMode: 511
           name: {{ .Values.fluentd.name }}-config
-       - name: varrunfluentd
+      - name: varrunfluentd
         hostPath:
-          path: /var/run/fluentd
-          type: DirectoryOrCreate
+         path: /var/run/fluentd
+         type: DirectoryOrCreate
 {{- end }}

--- a/helm/fluent-logshipping-app/templates/fluentd/deployment.yaml
+++ b/helm/fluent-logshipping-app/templates/fluentd/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.fluentd.aws.cloudWatch.enabled .Values.fluentd.aws.S3.enabled }}
+{{ $awsRole := coalesce .Values.fluentd.aws.role .Values.fluentd.aws.S3.role "NO_ROLE_SET_CHECK_VALUES" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,7 @@ spec:
     metadata:
       annotations:
         {{- if .Values.fluentd.aws.kiam }}
-        iam.amazonaws.com/role: {{ .Values.fluentd.aws.S3.role }}
+        iam.amazonaws.com/role: {{ $awsRole | quote }}
         {{- end }}
         releasetime: {{ now | quote }}
         releaseRevision: {{ .Release.Revision | quote }}

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -42,6 +42,7 @@ fluentd:
 
   aws:
     kiam: false
+    role: ""
     cloudWatch:
       enabled: false
       region: ""
@@ -53,7 +54,7 @@ fluentd:
       bucketRegion: ""
       bucketPathPrefix: "gs-"
       account: "00000000000"
-      role: "my-role"
+      role: ""
       grant_full_control: ""
       s3_object_key_format: "%{path}%{time_slice}_%{index}.%{file_extension}"
   azure:


### PR DESCRIPTION
The output for AWS supports S3 and Cloudwatch, but the role is only defined
for S3. So the role should be a level higher.

The implementation in this commit, will support both role levels, as I
didn't want to break current config.

This commit will use `fluentd.aws.role`, and if that isn't set then it will
use
`fluentd.aws.S3.role`. As a fall back it will set the role as
`NO_ROLE_SET_CHECK_VALUES`