### PR TITLE
AWS outputs split based on INPUT and also read journald logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Correct the output config format for AWS outputs
+- Correct the output config format for AWS outputs (split them based on input)
+- Mount journald path and set it in fluent-bit config
 
 ## v0.6.0
 _Note: Jumping to next minor version as we are dropping fluentd_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## Unreleased
 
+### Fixed
+
+- Correct the output config format for AWS outputs
+
 ## v0.6.0
 _Note: Jumping to next minor version as we are dropping fluentd_
 

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -260,25 +260,84 @@ data:
 
   {{- if .Values.outputs.aws.S3.enabled }}
   outputs-aws-s3.conf: |
-    Name                         s3
-    Match                        *
-    bucket                       {{ .Values.outputs.aws.S3.bucketPathPrefix }}{{ .Values.outputs.aws.S3.bucketName }}
-    region                       {{ .Values.outputs.aws.region }}
-    total_file_size              {{ .Values.outputs.aws.S3.totalFileSize }}
-    s3_key_format                {{ .Values.outputs.aws.S3.s3_object_key_format }}
-    s3_key_format_tag_delimiters .-_
-    store_dir                    ${storage_path}/S3
+    [OUTPUT]
+        Name                         s3
+        Match                        audit.ssh.**
+        bucket                       {{ .Values.outputs.aws.S3.bucketPathPrefix }}{{ .Values.outputs.aws.S3.bucketNamePrefix }}-ssh
+        region                       {{ .Values.outputs.aws.region }}
+        total_file_size              {{ .Values.outputs.aws.S3.totalFileSize }}
+        s3_key_format                {{ .Values.outputs.aws.S3.s3_object_key_format }}
+        s3_key_format_tag_delimiters .-_
+        store_dir                    ${storage_path}/S3
+
+    [OUTPUT]
+        Name                         s3
+        Match                        syslog.**
+        bucket                       {{ .Values.outputs.aws.S3.bucketPathPrefix }}{{ .Values.outputs.aws.S3.bucketNamePrefix }}-syslog
+        region                       {{ .Values.outputs.aws.region }}
+        total_file_size              {{ .Values.outputs.aws.S3.totalFileSize }}
+        s3_key_format                {{ .Values.outputs.aws.S3.s3_object_key_format }}
+        s3_key_format_tag_delimiters .-_
+        store_dir                    ${storage_path}/S3
+
+    [OUTPUT]
+        Name                         s3
+        Match                        kubernetes.**
+        bucket                       {{ .Values.outputs.aws.S3.bucketPathPrefix }}{{ .Values.outputs.aws.S3.bucketNamePrefix }}-containers
+        region                       {{ .Values.outputs.aws.region }}
+        total_file_size              {{ .Values.outputs.aws.S3.totalFileSize }}
+        s3_key_format                {{ .Values.outputs.aws.S3.s3_object_key_format }}
+        s3_key_format_tag_delimiters .-_
+        store_dir                    ${storage_path}/S3
+
+    [OUTPUT]
+        Name                         s3
+        Match                        audit.kubernetes.**
+        bucket                       {{ .Values.outputs.aws.S3.bucketPathPrefix }}{{ .Values.outputs.aws.S3.bucketNamePrefix }}-kubernetes-audit
+        region                       {{ .Values.outputs.aws.region }}
+        total_file_size              {{ .Values.outputs.aws.S3.totalFileSize }}
+        s3_key_format                {{ .Values.outputs.aws.S3.s3_object_key_format }}
+        s3_key_format_tag_delimiters .-_
+        store_dir                    ${storage_path}/S3
   {{- end }}
 
   {{- if or .Values.outputs.aws.cloudWatch.enabled }}
   outputs-aws-cloudwatch.conf: |
-    Name               cloudwatch_logs
-    Match              *
-    region             {{ .Values.outputs.aws.region }}
-    log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-    log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamName }}
-    log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
-    auto_create_group  On
+    [OUTPUT]
+        Name               cloudwatch_logs
+        Match              audit.ssh.**
+        region             {{ .Values.outputs.aws.region }}
+        log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-ssh
+        log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
+        auto_create_group  true
+
+    [OUTPUT]
+        Name               cloudwatch_logs
+        Match              syslog.**
+        region             {{ .Values.outputs.aws.region }}
+        log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-syslog
+        log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
+        auto_create_group  true
+
+    [OUTPUT]
+        Name               cloudwatch_logs
+        Match              kubernetes.**
+        region             {{ .Values.outputs.aws.region }}
+        log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-containers
+        log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
+        auto_create_group  true
+
+    [OUTPUT]
+        Name               cloudwatch_logs
+        Match              audit.kubernetes.**
+        region             {{ .Values.outputs.aws.region }}
+        log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-kubernetes-audit
+        log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
+        auto_create_group  true
   {{- end }}
 
   parsers.conf: |

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -65,6 +65,7 @@ data:
   inputs-syslog.conf: |
     [INPUT]
         Name              systemd
+        Path              /run/log/journal
         Tag               syslog.*
         Parser            syslog
         DB                ${input_database_path}/syslog.db
@@ -76,6 +77,7 @@ data:
     [INPUT]
         Name              systemd
         Tag               audit.ssh.*
+        Path              /run/log/journal
         Parser            syslog
         DB                ${input_database_path}/audit_ssh.db
         Systemd_Filter    SYSLOG_IDENTIFIER=sshd

--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -76,6 +76,9 @@ spec:
             port: {{ .Values.fluentbit.port }}
           initialDelaySeconds: 10
         volumeMounts:
+        - mountPath: /run/log/journal/
+          name: runlogjournal
+          readOnly: true
         - name: varlog
           mountPath: /var/log
           readOnly: true
@@ -92,6 +95,9 @@ spec:
           readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
       - name: varlog
         hostPath:
           path: /var/log

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -36,11 +36,11 @@ outputs:
     cloudWatch:
       enabled: false
       logGroupName: "my-cluster"
-      logStreamName: "example-stream"
+      logStreamNamePrefix: "example-stream"
       logRetentionDays: -1
     S3:
       enabled: false
-      bucketName: "my-cluster-logs"
+      bucketNamePrefix: "my-cluster-logs"
       bucketPathPrefix: "gs-"
       totalFileSize: "100M"
       s3_object_key_format: "%{path}%{time_slice}_%{index}.%{file_extension}"


### PR DESCRIPTION
 - Split the outputs based on input for AWS
 - Mount journald host path in the pod
 - Set the journald path in fluent-bit config