### PR TITLE
Use Node name as part of logstream name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## Unreleased
 
+### Added
+
+- [Cloudwatch Output] Use Node name as part of the log stream name
+
 ### Fixed
 
 - Correct the output config format for AWS outputs (split them based on input)

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -310,7 +310,7 @@ data:
         Match              audit.ssh.**
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-ssh
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-ssh-${K8S_NODE_NAME}
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
 
@@ -319,7 +319,7 @@ data:
         Match              syslog.**
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-syslog
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-syslog-${K8S_NODE_NAME}
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
 
@@ -328,7 +328,7 @@ data:
         Match              kubernetes.**
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-containers
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-containers-${K8S_NODE_NAME}
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
 
@@ -337,7 +337,7 @@ data:
         Match              audit.kubernetes.**
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-kubernetes-audit
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamNamePrefix }}-kubernetes-audit-${K8S_NODE_NAME}
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
   {{- end }}

--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -36,6 +36,11 @@ spec:
       - name: {{ .Values.fluentbit.name }}
         image: {{ .Values.image.registry }}/{{ .Values.fluentbit.image.name }}:{{ .Values.fluentbit.image.tag }}
         env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         {{- if .Values.outputs.azure.logAnalytics.enabled }}
         - name: FLUENT_AZURE_WORKSPACE_ID
           valueFrom:


### PR DESCRIPTION
Cloudwatch is expected different names. If you use the same name,you can get an
error message so add the node name to ensure it's pretty unique