### PR TITLE
Add additional options to handle back pressure better

### DIFF
--- a/helm/fluent-logshipping-app/Configuration.md
+++ b/helm/fluent-logshipping-app/Configuration.md
@@ -11,6 +11,10 @@ The following table lists the configurable parameters of the fluent-logshipping-
 | `fluentbit.groupID`                                   | fluentbit group ID                                                                | `1000`            |
 | `fluentbit.logLevel`                                  | log level collected by fluentbit                                                  | `info`            |
 | `fluentbit.flushFrequencyInSeconds`                   | Number of seconds between flushes to the forwards                                 | `5`               |
+| `fluentbit.memBufferLimit`                            | Size of the memory buffer limit                                                   | `10MB`            |
+| `fluentbit.backlogMemLimit`                           | Backlog Memory Limit                                                              | `50M`             |
+| `fluentbit.storageMaxChunksUp`                        | Maximum number of chunks to consider `up` in memory                               | `128`             |
+| `fluentbit.inputStorageTypes.{}`                      | Defined for each input type, determines what storage to use for buffers. Valid values are `memory` or `filesystem` | `memory` |
 | `outputs.name`                                        | outputs deployment name                                                           | `outputs`         |
 | `outputs.replicas`                                    | outputs replicas                                                                  | `2`               |
 | `outputs.port`                                        | outputs port                                                                      | `24224`           |

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
   # ======================================================
   fluent-bit.conf: |
     # Setting the memory buffer limit for all the input plugins to handle backpressure (cf. https://docs.fluentbit.io/manual/v/0.12/configuration/backpressure)
-    @SET input_memory_buffer_limit=10MB
+    @SET input_memory_buffer_limit={{ .Values.fluentbit.memBufferLimit }}
     @SET input_refresh_interval_in_seconds=10
     @SET input_skip_long_lines=on
 
@@ -32,7 +32,8 @@ data:
         storage.path              ${storage_path}
         storage.sync              normal
         storage.checksum          off
-        storage.backlog.mem_limit 50M
+        storage.max_chunks_up     {{ .Values.fluentbit.storageMaxChunksUp }}
+        storage.backlog.mem_limit {{ .Values.fluentbit.backlogMemLimit }}
 
     @INCLUDE inputs.conf
     @INCLUDE filters.conf
@@ -57,6 +58,7 @@ data:
         # Buffering options
         Mem_Buf_Limit     ${input_memory_buffer_limit}
         Buffer_Max_Size   ${input_buffer_max_size}
+        storage.type      {{ .Values.fluentbit.inputStorageTypes.container }}
 
         # The interval of refreshing the list of watched files in seconds
         Refresh_Interval  ${input_refresh_interval_in_seconds}
@@ -69,6 +71,7 @@ data:
         Tag               syslog.*
         Parser            syslog
         DB                ${input_database_path}/syslog.db
+        storage.type      {{ .Values.fluentbit.inputStorageTypes.syslog }}
         Mem_Buf_Limit     ${input_memory_buffer_limit}
         Strip_Underscores on
 
@@ -82,6 +85,7 @@ data:
         DB                ${input_database_path}/audit_ssh.db
         Systemd_Filter    SYSLOG_IDENTIFIER=sshd
         Mem_Buf_Limit     ${input_memory_buffer_limit}
+        storage.type      {{ .Values.fluentbit.inputStorageTypes.sshd }}
         Strip_Underscores on
 
     # Get the kubernetes api server audit logs
@@ -91,6 +95,7 @@ data:
         Path              /var/log/apiserver/audit.log
         Parser            json
         DB                ${input_database_path}/audit_kubernetes.db
+        storage.type      {{ .Values.fluentbit.inputStorageTypes.audit }}
 
         # Buffering options
         Buffer_Max_Size   ${input_buffer_max_size}

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -27,6 +27,16 @@ fluentbit:
 
   logLevel: info
   flushFrequencyInSeconds: 5
+  backlogMemLimit: "50M"
+  memBufferLimit: "10MB"
+  storageMaxChunksUp: 128
+
+
+  inputStorageTypes:
+    audit: "memory"
+    container: "memory"
+    sshd: "memory"
+    syslog: "memory"
 
 outputs:
   aws:


### PR DESCRIPTION
None of the inputs handled back pressure due memory buffer being hit, this commit
introduces a couple new values that can be adjusted depending on workload. It
also allows inputs to buffer to disk (and memory).
