### PR TITLE
Make daemonset resources configurable

### DIFF
--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -66,12 +66,9 @@ spec:
               key: ElasticsearchPassword
         {{- end }}
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          {{- with .Values.resources }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.fluentbit.port }}

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -111,3 +111,10 @@ giantswarm:
 tolerations:
   - operator: "Exists"
     effect: "NoSchedule"
+
+resources:
+  limits:
+    memory: 200Mi
+  requests:
+    cpu: 500m
+    memory: 100Mi


### PR DESCRIPTION
Use defaults based on recommendations from AWS
https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
