### PR TITLE
Configure docker registry and send md5 header for s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add container registry domain support to images.
+ 
+### Changed
+
+- Send md5 header for s3 outputs.
+
 ## [1.2.0] - 2022-07-11
 
 ### Changed

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -448,6 +448,7 @@ data:
         {{- end }}
         s3_key_format_tag_delimiters .-_
         store_dir                    ${storage_path}/S3
+        send_content_md5             true
     [OUTPUT]
         Name                         s3
         Match                        audit.ssh.execve.**
@@ -469,6 +470,7 @@ data:
         {{- end }}
         s3_key_format_tag_delimiters .-_
         store_dir                    ${storage_path}/S3
+        send_content_md5             true
   {{- end }}
 
   {{- if has "syslog" .Values.outputs.aws.S3.inputLogTypes }}
@@ -493,6 +495,7 @@ data:
         {{- end }}
         s3_key_format_tag_delimiters .-_
         store_dir                    ${storage_path}/S3
+        send_content_md5             true
   {{- end }}
 
   {{- if has "containers" .Values.outputs.aws.S3.inputLogTypes }}
@@ -517,6 +520,7 @@ data:
         {{- end }}
         s3_key_format_tag_delimiters .-_
         store_dir                    ${storage_path}/S3
+        send_content_md5             true
   {{- end }}
 
   {{- if has "audit" .Values.outputs.aws.S3.inputLogTypes }}
@@ -541,6 +545,7 @@ data:
         {{- end }}
         s3_key_format_tag_delimiters .-_
         store_dir                    ${storage_path}/S3
+        send_content_md5             true
  {{- end }}
  {{- end }}
 

--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         runAsGroup: {{ .Values.fluentbit.groupID }}
       containers:
       - name: fluent-bit
-        image: {{ .Values.fluentbit.image.name }}:{{ .Values.fluentbit.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.registry.domain }}/{{ .Values.fluentbit.image.name }}:{{ .Values.fluentbit.image.tag | default .Chart.AppVersion }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -11,7 +11,7 @@ project:
   commit: "[[ .SHA ]]"
 
 registry:
-  domain: quay.io
+  domain: docker.io
 
 fluentbit:
   port: 5170


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23060

We need to send the md5 header to allow s3 putobject when Object lock is enabled on the buckets