### PR TITLE
Parametrize log stream names to reduce cloudwatch throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use fluent-bit image with aws-for-fluent-bit plugins to be able to configure the log-stream-name and reduce risks of throttling.
+
 ## [1.3.0] - 2022-08-02
 
 ### Added

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -553,7 +553,7 @@ data:
   outputs-aws-cloudwatch.conf: |
   {{- if has "sshd" .Values.outputs.aws.cloudWatch.inputLogTypes }}
     [OUTPUT]
-        Name               cloudwatch_logs
+        Name               cloudwatch
         Match              audit.ssh.sshd.**
         {{- if .Values.outputs.aws.role }}
         role_arn           {{ .Values.outputs.aws.role }}
@@ -564,7 +564,7 @@ data:
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
     [OUTPUT]
-        Name               cloudwatch_logs
+        Name               cloudwatch
         Match              audit.ssh.execve.**
         {{- if .Values.outputs.aws.role }}
         role_arn           {{ .Values.outputs.aws.role }}
@@ -578,7 +578,7 @@ data:
 
   {{- if has "syslog" .Values.outputs.aws.cloudWatch.inputLogTypes }}
     [OUTPUT]
-        Name               cloudwatch_logs
+        Name               cloudwatch
         Match              syslog.**
         {{- if .Values.outputs.aws.role }}
         role_arn           {{ .Values.outputs.aws.role }}
@@ -592,28 +592,28 @@ data:
 
   {{- if has "containers" .Values.outputs.aws.cloudWatch.inputLogTypes }}
     [OUTPUT]
-        Name               cloudwatch_logs
+        Name               cloudwatch
         Match              kubernetes.**
         {{- if .Values.outputs.aws.role }}
         role_arn           {{ .Values.outputs.aws.role }}
         {{- end }}
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamName }}-containers
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamName }}-containers-$(kubernetes['namespace_name'])/$(kubernetes['container_name'])
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
   {{- end }}
 
   {{- if has "audit" .Values.outputs.aws.cloudWatch.inputLogTypes }}
     [OUTPUT]
-        Name               cloudwatch_logs
+        Name               cloudwatch
         Match              audit.kubernetes.**
         {{- if .Values.outputs.aws.role }}
         role_arn           {{ .Values.outputs.aws.role }}
         {{- end }}
         region             {{ .Values.outputs.aws.region }}
         log_group_name     {{ .Values.outputs.aws.cloudWatch.logGroupName }}
-        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamName }}-k8s-audit
+        log_stream_name    {{ .Values.outputs.aws.cloudWatch.logStreamName }}-${K8S_NODE_NAME}-k8s-audit
         log_retention_days {{ .Values.outputs.aws.cloudWatch.logRetentionDays }}
         auto_create_group  true
   {{- end }}

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -25,7 +25,8 @@ fluentbit:
   image:
     name: giantswarm/fluent-bit
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: "1.7.9-systemd247"
+    # This image fixes some systemd issues fixed in 1.8.x and adds the aws-for-fluent-bit cloudwatch plugin to be able to template cloudwatch log stream names.
+    tag: "1.7.9-systemd247-aws-plugins"
 
   logLevel: info
   flushFrequencyInSeconds: 5


### PR DESCRIPTION
Tested on anteater (only place I could)

Towards https://github.com/giantswarm/giantswarm/issues/22993

```
time="2022-08-03T15:29:58Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/encryption-provider-operator does not exist in log group anteater-control-plane"
time="2022-08-03T15:29:58Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/encryption-provider-operator in group anteater-control-plane"
time="2022-08-03T15:29:59Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-kube-system/k8s-api-server does not exist in log group anteater-control-plane"
time="2022-08-03T15:29:59Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-kube-system/k8s-api-server in group anteater-control-plane"
time="2022-08-03T15:30:04Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/kyverno does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:04Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/kyverno in group anteater-control-plane"
time="2022-08-03T15:30:06Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/net-exporter does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:06Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/net-exporter in group anteater-control-plane"
time="2022-08-03T15:30:07Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/promxy-app does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:07Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/promxy-app in group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/silence-operator does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/silence-operator in group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/starboard-exporter does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/starboard-exporter in group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/tokend does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:11Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/tokend in group anteater-control-plane"
time="2022-08-03T15:30:15Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/app-admission-controller does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:15Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-giantswarm/app-admission-controller in group anteater-control-plane"
time="2022-08-03T15:30:15Z" level=info msg="[cloudwatch 3] Log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/fluent-bit does not exist in log group anteater-control-plane"
time="2022-08-03T15:30:15Z" level=info msg="[cloudwatch 3] Created log stream control-plane-ip-172-19-5-221.eu-west-1.compute.internal-containers-monitoring/fluent-bit in group anteater-control-plane"
```