### PR TITLE
Move hostpath to emptydir for temp storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to fluent-bit 2.2.0
+- Use emptyDir instead of hostPath for filesystem storage type.
+
 ## [3.0.2] - 2023-10-02
 
 ### Changed

--- a/helm/fluent-logshipping-app/Chart.yaml
+++ b/helm/fluent-logshipping-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 2.1.6
+appVersion: 2.2.0
 description: The Log Shipping App forwards cluster logs to storage backends
 engine: gotpl
 home: https://github.com/giantswarm/fluent-logshipping-app

--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -94,14 +94,15 @@ spec:
         - name: var-log
           mountPath: /var/log
           readOnly: true
-        - name: var-tmp-fluent-bit
-          mountPath: /var/tmp/fluent-bit
         - name: fluent-bit-config
           mountPath: /fluent-bit/etc/
+          readOnly: true
         ## Needed for syslog to work as the syslog plugins needs this id
         - name: etc-machine-id
           mountPath: /etc/machine-id
           readOnly: true
+        - name: tmp-storage
+          mountPath: /var/tmp/fluent-bit
       terminationGracePeriodSeconds: 10
       volumes:
       - name: systemd-log
@@ -110,10 +111,6 @@ spec:
       - name: var-log
         hostPath:
           path: /var/log
-      - name: var-tmp-fluent-bit
-        hostPath:
-          path: /var/tmp/fluent-bit
-          type: DirectoryOrCreate
       - name: fluent-bit-config
         configMap:
           name: {{ include "resource.default.name" . }}-configmap
@@ -121,6 +118,9 @@ spec:
         hostPath:
           path: /etc/machine-id
           type: File
+      - name: tmp-storage
+        emptyDir:
+          sizeLimit: {{ .Values.fluentbit.storage.sizeLimit }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/helm/fluent-logshipping-app/templates/psp.yaml
+++ b/helm/fluent-logshipping-app/templates/psp.yaml
@@ -24,6 +24,7 @@ spec:
     - 'configMap'
     - 'hostPath'
     - 'projected'
+    - 'emptyDir'
   allowPrivilegeEscalation: true
   hostNetwork: false
   hostIPC: false

--- a/helm/fluent-logshipping-app/values.schema.json
+++ b/helm/fluent-logshipping-app/values.schema.json
@@ -60,6 +60,14 @@
                 "protocol": {
                     "type": "string"
                 },
+                "storage": {
+                    "type": "object",
+                    "properties": {
+                        "sizeLimit": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "storageMaxChunksUp": {
                     "type": "integer"
                 },

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -31,13 +31,17 @@ fluentbit:
     # -- Overrides the image tag whose default is the chart's appVersion
     # We use a custom version here that is built here https://github.com/giantswarm/fluent-bit/tree/v0.1.0.
     # This version adds a shell in the container so we can use the exec plugin as well as install ausearch.
-    # It is based on version 2.1.6 of fluent-bit.
-    tag: "0.1.0"
+    # It is based on version 2.2.0 of fluent-bit.
+    tag: "0.2.0"
 
   logLevel: info
   flushFrequencyInSeconds: 5
   backlogMemLimit: "50M"
   memBufferLimit: "10MB"
+
+  storage:
+    sizeLimit: 15Gi
+
   storageMaxChunksUp: 128
 
   inputStorageTypes:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29292


We cannot use a PVC as daemonset would only work with NFS so let's try to use emptyDir that would use the kubelet directory instead of the root one so the node will not be rendered useless