### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [3.1.0] - 2023-12-19
 
 ### Changed

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -15,7 +15,7 @@ project:
   commit: "[[ .SHA ]]"
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 fluentbit:
   port: 5170
@@ -55,10 +55,10 @@ serviceAccount:
 
 outputs:
   inputLogTypes: &logTypes
-  - sshd
-  - containers
-  - syslog
-  - audit
+    - sshd
+    - containers
+    - syslog
+    - audit
   aws:
     kiam: false
     role: ""


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
