### PR TITLE
Deploy resources only if the ds is rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Renders resources only if the daemonset is deployed.
+
 ## [3.1.1] - 2023-12-20
 
 ### Changed

--- a/helm/fluent-logshipping-app/templates/kyverno-policy-exception.yaml
+++ b/helm/fluent-logshipping-app/templates/kyverno-policy-exception.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
 {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
 apiVersion: kyverno.io/v2alpha1
@@ -49,5 +50,6 @@ spec:
         - {{ .Release.Namespace }}
         names:
         - {{ include "resource.default.name" . }}*
-  {{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/helm/fluent-logshipping-app/templates/psp.yaml
+++ b/helm/fluent-logshipping-app/templates/psp.yaml
@@ -1,6 +1,6 @@
+{{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
-{{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/fluent-logshipping-app/templates/servicemonitor.yaml
+++ b/helm/fluent-logshipping-app/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 {{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -15,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/fluent-logshipping-app/templates/vpa.yaml
+++ b/helm/fluent-logshipping-app/templates/vpa.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 {{ if eq (include "resource.vpa.enabled" .) "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -25,4 +26,5 @@ spec:
     name:  {{ include "resource.default.name"  . }}
   updatePolicy:
     updateMode: Auto
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Well, we currently deploy some resources (VPA, ServiceMOnitor and kyverno policy exception) even if the chart main items are not rendered.

This will reduce resources on MCs and prevent messages in VPA like such:

```
E0201 19:38:56.057155       1 cluster_feeder.go:532] Cannot get target selector from VPA's targetRef. Reason: DaemonSet monitoring/fluent-logshipping-app does not exist
E0201 19:39:56.057021       1 cluster_feeder.go:532] Cannot get target selector from VPA's targetRef. Reason: DaemonSet monitoring/fluent-logshipping-app does not exist
```