### PR TITLE
Upgrade fluent bit to 3.0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,39 +41,11 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: "push-to-azure-app-collection"
-          context: "architect"
-          app_name: "fluent-logshipping-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "azure-app-collection"
-          requires:
-            - push-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           name: "push-to-vsphere-app-collection"
           context: "architect"
           app_name: "fluent-logshipping-app"
           app_namespace: "monitoring"
           app_collection_repo: "vsphere-app-collection"
-          requires:
-            - push-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: push-to-gcp-app-collection
-          context: architect
-          app_name: "fluent-logshipping-app"
-          app_namespace: "monitoring"
-          app_collection_repo: "gcp-app-collection"
           requires:
             - push-to-control-plane-catalog
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to fluent-bit 3.0.6 to fix some recent CVEs.
+
 ## [4.2.0] - 2024-03-25
 
 ### Changed

--- a/helm/fluent-logshipping-app/Chart.yaml
+++ b/helm/fluent-logshipping-app/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: 2.2.0
+apiVersion: v2
+appVersion: 3.0.6
 description: The Log Shipping App forwards cluster logs to storage backends
 engine: gotpl
 home: https://github.com/giantswarm/fluent-logshipping-app

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -19,10 +19,10 @@ fluentbit:
   image:
     name: giantswarm/fluent-bit-audited
     # -- Overrides the image tag whose default is the chart's appVersion
-    # We use a custom version here that is built here https://github.com/giantswarm/fluent-bit/tree/v0.1.0.
+    # We use a custom version here that is built here https://github.com/giantswarm/fluent-bit.
     # This version adds a shell in the container so we can use the exec plugin as well as install ausearch.
-    # It is based on version 2.2.0 of fluent-bit.
-    tag: "0.2.0"
+    # It is based on version 3.0.6 of fluent-bit.
+    tag: "0.3.0"
 
   logLevel: info
   flushFrequencyInSeconds: 5


### PR DESCRIPTION
This PR upgrades fluent-bit to the latest version towards https://github.com/giantswarm/giantswarm/issues/30874