### PR TITLE
Set priorityClassName to prometheus for fluentd daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added priorityClassName=prometheus to the fluent-bit daemonset.
+
+### Removed
+
+- Removed NoSchedule node taint toleration from fluent-bit daemonset.
+
 ## [5.0.0] - 2024-05-28
 
 ### Changed

--- a/helm/fluent-logshipping-app/templates/daemonset.yaml
+++ b/helm/fluent-logshipping-app/templates/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
       {{- with .Values.tolerations }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      priorityClassName: prometheus
       serviceAccountName: {{ include "resource.default.name" . }}
       securityContext:
         runAsUser: {{ .Values.fluentbit.userID }}

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -129,11 +129,6 @@ kyvernoPolicyExceptions:
   enabled: true
   namespace: giantswarm
 
-# Tolerate all nodes with NoSchedule taints
-tolerations:
-  - operator: "Exists"
-    effect: "NoSchedule"
-
 resources:
   limits:
     memory: 200Mi


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30815

Set priorityClassName to prometheus for fluentd daemonset to fix scheduling issues.

I also removed the NoSchedule node taint toleration, as I felt this is wrong for fluentbit to be scheduled on such nodes.