### PR TITLE
Bump fluent-bit to 3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to fluent-bit 3.1.6 to fix some recent CVEs.
+
 ## [5.1.1] - 2024-06-18
 
 ### Fixed

--- a/helm/fluent-logshipping-app/Chart.yaml
+++ b/helm/fluent-logshipping-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 3.0.6
+appVersion: 3.1.6
 description: The Log Shipping App forwards cluster logs to storage backends
 engine: gotpl
 home: https://github.com/giantswarm/fluent-logshipping-app

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -28,8 +28,8 @@ fluentbit:
     # -- Overrides the image tag whose default is the chart's appVersion
     # We use a custom version here that is built here https://github.com/giantswarm/fluent-bit.
     # This version adds a shell in the container so we can use the exec plugin as well as install ausearch.
-    # It is based on version 3.0.6 of fluent-bit.
-    tag: "0.3.0"
+    # It is based on version 3.1.6 of fluent-bit.
+    tag: "0.4.0"
 
   logLevel: info
   flushFrequencyInSeconds: 5


### PR DESCRIPTION
This bumps fluent-bit at a customer's request to address cves