### PR TITLE
Use latest fluent-bit image to fix some cves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix some CVEs in the fluent-bit image.
+
 ## [5.2.0] - 2024-08-29
 
 ### Changed

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -29,7 +29,7 @@ fluentbit:
     # We use a custom version here that is built here https://github.com/giantswarm/fluent-bit.
     # This version adds a shell in the container so we can use the exec plugin as well as install ausearch.
     # It is based on version 3.1.6 of fluent-bit.
-    tag: "0.4.0"
+    tag: "0.4.1"
 
   logLevel: info
   flushFrequencyInSeconds: 5


### PR DESCRIPTION
This bumps the fluent-bit version which uses debian bookworm instead of debian bullseye with has a lot more critical CVEs