### PR TITLE
fix: fixed the regex of the nginx parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix Nginx Parser.
+- Fix Nginx Parser based on the upstream parser.
 
 ## [5.2.1] - 2024-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Nginx Parser.
+
 ## [5.2.1] - 2024-09-02
 
 ### Fixed

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -200,7 +200,7 @@ data:
     [PARSER]
         Name   nginx
         Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")
         Time_Key time
         Time_Format %d/%b/%Y:%H:%M:%S %z
 


### PR DESCRIPTION
This PR addresses an issue with the current regular expression for Nginx logs in the chart, which was not correctly matching the log format from the Nginx process. Fluent Bit provides a [list of parsers](https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf) that can be used directly to ensure proper log parsing. This PR updates the Nginx log parser configuration to align with the correct regex, fixing the log parsing issue.