### PR TITLE
Tune kube filter Buffer_Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow to tune kube filter's buffer size
+
 ## [5.3.1] - 2024-11-04
 
 ### Fixed

--- a/helm/fluent-logshipping-app/templates/configmap.yaml
+++ b/helm/fluent-logshipping-app/templates/configmap.yaml
@@ -151,6 +151,7 @@ data:
         Merge_Log_Key       log_processed
         K8S-Logging.Parser  On
         K8S-Logging.Exclude Off
+        Buffer_Size         {{ .Values.fluentbit.kubeAPIBufferSize }}
 
     [FILTER]
         Name   record_modifier

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -53,6 +53,7 @@ fluentbit:
       sizeLimit: 1Gi
 
   storageMaxChunksUp: 128
+  kubeAPIBufferSize: "64KB"
 
   buffering:
     audit: "memory"


### PR DESCRIPTION
Set a value to tune kube filter's buffer size.
Also, set a default value to 64KB instead of 32KB.

This helps solve cases where fluentbit issues lots of `[ warn] [http_client] cannot increase buffer` logs and does unneeded queries to kube API.