### PR TITLE
update kyverno policy exception version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update Kyverno PolicyExceptions to v2.
+
 ## [5.4.0] - 2025-02-28
 
 ### Changed

--- a/helm/fluent-logshipping-app/Chart.yaml
+++ b/helm/fluent-logshipping-app/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 appVersion: 3.1.9
 description: The Log Shipping App forwards cluster logs to storage backends
-engine: gotpl
 home: https://github.com/giantswarm/fluent-logshipping-app
 icon: https://s.giantswarm.io/app-icons/1/png/fluent-logshipping-app-light.png
 name: fluent-logshipping-app

--- a/helm/fluent-logshipping-app/templates/kyverno-policy-exception.yaml
+++ b/helm/fluent-logshipping-app/templates/kyverno-policy-exception.yaml
@@ -1,7 +1,12 @@
 {{- if and .Values.outputs .Values.outputs.inputLogTypes }}
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+apiVersion: kyverno.io/v2beta1
+{{- else -}}
 apiVersion: kyverno.io/v2alpha1
+{{- end }}
 kind: PolicyException
 metadata:
   annotations:
@@ -50,6 +55,5 @@ spec:
         - {{ .Release.Namespace }}
         names:
         - {{ include "resource.default.name" . }}*
-{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/34101

This pull request updates the handling of Kyverno PolicyExceptions in the chart to use the new v2 API version. This change ensures compatibility with the latest Kyverno release and improves future maintainability.