### PR TITLE
feat: enable priority class by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable priority class by default to ensure fluentbit can preempt lower priority pods on overloaded nodes.
+
 ## [5.5.2] - 2026-02-16
 
 ### Added

--- a/helm/fluent-logshipping-app/values.yaml
+++ b/helm/fluent-logshipping-app/values.yaml
@@ -9,8 +9,8 @@ registry:
 
 fluentbit:
   priorityClass:
-    enabled: false
-    create: false
+    enabled: true
+    create: true
     # The value is only relevant when using the custom priority class.
     value: 200000000
     name: fluentbit


### PR DESCRIPTION
## Summary

- Enable `fluentbit.priorityClass.enabled` and `fluentbit.priorityClass.create` defaults to `true`
- This ensures fluentbit can preempt lower priority pods on overloaded nodes, allowing karpenter/cluster-autoscaler to kick in

Fixes https://github.com/giantswarm/giantswarm/issues/35485

## Test plan

- [ ] Deploy the app on a WC and verify the `fluentbit` PriorityClass resource is created
- [ ] Verify the fluentbit DaemonSet pods have `priorityClassName: fluentbit` set
- [ ] Verify existing deployments with custom `priorityClass` config are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)